### PR TITLE
Fix error on Firefox when First-Party Isolation is enabled

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,6 +23,7 @@ async function save_cookies(changeInfo) {
 
 		if (isFirefox) {
 			details['partitionKey'] = {}; // Firefox only, return all cookies from partitioned and unpartitioned storage
+			details['firstPartyDomain'] = null; // Required when First-Party Isolation is enabled
 		}
 
 		chrome.cookies.getAll(details).then((cookies) => {

--- a/options.js
+++ b/options.js
@@ -24,6 +24,7 @@ async function save_cookies(changeInfo) {
 
 		if (isFirefox) {
 			details['partitionKey'] = {}; // Firefox only, return all cookies from partitioned and unpartitioned storage
+			details['firstPartyDomain'] = null; // Required when First-Party Isolation is enabled
 		}
 
 		chrome.cookies.getAll(details).then((cookies) => {
@@ -171,6 +172,7 @@ document.querySelector('#save').addEventListener('click', () => {
 
 				if (isFirefox) {
 					details['partitionKey'] = {}; // Firefox only, return all cookies from partitioned and unpartitioned storage
+					details['firstPartyDomain'] = null; // Required when First-Party Isolation is enabled
 				}
 
 				chrome.cookies.getAll(details).then((cookies) => {


### PR DESCRIPTION
Fix
> Uncaught (in promise) Error: First-Party Isolation is enabled, but the required 'firstPartyDomain' attribute was not set.

when `privacy.firstparty.isolate` is `true`

See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation